### PR TITLE
Deprecate consumeReferrer() API (no-op since Bazaar 26.4.0)

### DIFF
--- a/Referrer/src/main/aidl/com/farsitel/bazaar/referrerprovider/ReferrerProviderService.aidl
+++ b/Referrer/src/main/aidl/com/farsitel/bazaar/referrerprovider/ReferrerProviderService.aidl
@@ -12,11 +12,22 @@ interface ReferrerProviderService {
     */
     Bundle getReferrer(String packageName);
     /**
-    * Consumes the referrer data for given package name. Users have to provide
-    * the right install time in order to consume the referrer data.
-    * @param packageName The package name of the user application
-    * @param installTimeMilliSeconds The install time which user has received from
-    * getReferrer()
+    * Consumes the referrer data for the given package name.
+    * <p>
+    * Users were previously required to provide the correct install time (retrieved from
+    * {@code getReferrer()}) in order to consume the referrer data.
+    * </p>
+    *
+    * <p><strong>Deprecated since Bazaar 26.4.0:</strong> This method is no longer supported.
+    * Referrer consumption has been made internal and automatic. As of this version, calling this
+    * method has no effect. Referrer data will now be consumed automatically within 90 days
+    * of installation or upon app uninstall/reinstall.</p>
+    *
+    * @param packageName The package name of the user application.
+    * @param installTimeMilliSeconds The install time (in milliseconds) as retrieved from {@code getReferrer()}.
+    *
+    * @deprecated Since Bazaar 26.4.0. This method is now a no-op and should no longer be used.
+    *             Referrer consumption is now handled internally.
     */
     void consumeReferrer(String packageName, long installTimeMilliSeconds);
 }

--- a/Referrer/src/main/java/com/cafebazaar/referrersdk/ReferrerClient.kt
+++ b/Referrer/src/main/java/com/cafebazaar/referrersdk/ReferrerClient.kt
@@ -1,8 +1,8 @@
 package com.cafebazaar.referrersdk
 
 import android.app.Application
-import com.cafebazaar.servicebase.state.ClientStateListener
 import com.cafebazaar.referrersdk.model.ReferrerDetails
+import com.cafebazaar.servicebase.state.ClientStateListener
 
 interface ReferrerClient {
     /**
@@ -28,8 +28,26 @@ interface ReferrerClient {
     fun getReferrerDetails(): ReferrerDetails?
 
     /**
-     * Consumes the referrer content in order to avoid getting repetitive referrer content
+     * Consumes the referrer data for the given package name.
+     * <p>
+     * Users were previously required to provide the correct install time (retrieved from
+     * {@code getReferrer()}) in order to consume the referrer data.
+     * </p>
+     *
+     * <p><strong>Deprecated since Bazaar 26.4.0:</strong> This method is no longer supported.
+     * Referrer consumption has been made internal and automatic. As of this version, calling this
+     * method has no effect. Referrer data will now be consumed automatically within 90 days
+     * of installation or upon app uninstall/reinstall.</p>
+     *
+     * @param installTime The install time (in milliseconds) as retrieved from {@code getReferrer()}.
+     *
+     * @deprecated Since Bazaar 26.4.0. This method is now a no-op and should no longer be used.
+     *             Referrer consumption is now handled internally.
      */
+    @Deprecated(
+        level = DeprecationLevel.WARNING,
+        message = "This functions is no-op from 26.4.0 of Bazaar and consume logic has become internal."
+    )
     fun consumeReferrer(installTime: Long)
 
     companion object {

--- a/app/src/main/java/ir/cafebazaar/referrersdksample/MainViewModel.kt
+++ b/app/src/main/java/ir/cafebazaar/referrersdksample/MainViewModel.kt
@@ -15,7 +15,7 @@ class MainViewModel(application: Application): AndroidViewModel(application) {
     private val stateListener = object : ClientStateListener {
 
         override fun onReady() {
-            getAndConsumeReferrer()
+            getReferrer()
         }
 
         override fun onError(clientError: ClientError) {
@@ -51,10 +51,9 @@ class MainViewModel(application: Application): AndroidViewModel(application) {
         }
     }
 
-    private fun getAndConsumeReferrer() {
+    private fun getReferrer() {
         referrerClient.getReferrerDetails()?.let { referrerDetails ->
             _referrerContent.postValue(referrerDetails)
-            referrerClient.consumeReferrer(referrerDetails.installBeginTimestampMilliseconds)
             referrerClient.endConnection()
         } ?: run {
             _errorMessage.postValue("THERE IS NO REFERRER")


### PR DESCRIPTION
### Description:

This PR deprecates the consumeReferrer(String packageName, long installTimeMilliSeconds) method in the AIDL interface.

#### Background

Starting from Bazaar 26.4.0, the logic for consuming referrer data has been moved to internal handling. The referrer will now be automatically consumed after 90 days or upon app uninstall/reinstall.

#### Changes

    Added a @deprecated JavaDoc tag to the consumeReferrer() method to indicate it is no longer supported.

    Annotated the method with @Deprecated to ensure tool and IDE support for warning developers.

    Updated documentation to guide developers and prevent continued usage.

#### Impact

    The method is now a no-op, and calling it has no effect.

    This change helps developers transition away from using the deprecated API and rely on the internal referrer handling mechanism.
    
    
####     Developer Guidance

    ⚠️ As of this merge, developers should only call getReferrer() once, ideally on the first open of the app.
    This prevents unnecessary load on the CafeBazaar app and aligns with the updated internal referrer handling logic.